### PR TITLE
Add compute.stdists() and compute.bwr() clustering metrics

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -5,5 +5,5 @@ exportPattern(".")
 
 # Import names
 importFrom("graphics", "arrows", "legend", "lines", "mtext", "plot", "points", "text")
-importFrom("stats", "median", "prcomp", "sd")
+importFrom("stats", "median", "prcomp", "sd", "dist")
 importFrom("utils", "read.table")

--- a/man/compute.bwr.Rd
+++ b/man/compute.bwr.Rd
@@ -1,0 +1,42 @@
+% Encoding: UTF-8
+\name{compute.bwr}
+\alias{compute.bwr}
+\title{Compute Between-Within-Ratio for Vowel Data}
+\description{
+  Computes the ratio of between-category distances to within-category distances, in a data frame of vowel formant data.
+}
+\usage{
+compute.bwr(vowels, use.f3 = FALSE)
+}
+\arguments{
+  \item{vowels}{A required data frame of the format: speaker_id, vowel_id, context, F1, F2, F3. The context column can be blank. The F3 column can also be blank if \code{use.f3} is \code{FALSE}.}
+  \item{use.f3}{A logical value indicating whether to include F3 values in the calculations. Default is \code{FALSE}.}
+}
+\details{
+  This function calculates the ratio of the mean between-category distance to the mean within-category distance for vowel formant data. The metric is calculated as the mean Euclidean distance between all data points belonging to different vowel categories divided by the mean Euclidean distance between all data points belonging to the same vowel categories. It can be used to compare the clustering of vowel productions across different normalization methods, as long as the dimensionality of data is the same. Larger values of this metric indicate better vowel category separation and smaller data spread within individual vowel categories.
+  By default, the function uses two formant frequencies (F1 and F2, or any corresponding normalized values), but for original data measured in Hz or data normalized using methods that return three values (such as Labov or Nearey), three-dimensional input is possible, based on the \code{use.f3} argument.
+}
+\value{
+  A numeric value representing the ratio of the mean between-category distance to the mean within-category distance.
+}
+\references{
+The "Between-Within-Ratio" metric is based on the description in:
+Miller, James D. 1989. Auditory-perceptual interpretation of the vowel. The Journal of the Acoustical society of America, 85(5), 2114-2134.
+
+The implementation in this package follows:
+Stolarski, Lukasz. under review. Efficacy of Vowel Normalization Methods for Factors Other than Inter-Speaker Variability.
+}
+\author{Stolarski, Lukasz <lukasz.stolarski@ujk.edu.pl>}
+\seealso{ \code{\link{compute.means}}, \code{\link{compute.medians}}, \code{\link{compute.sds}}, \code{\link{compute.stdists}} }
+\examples{
+# Example usage with F1 and F2
+data(ohiovowels)
+bwr.2d <- compute.bwr(ohiovowels)
+
+# Example usage with F1, F2, and F3
+bwr.3d <- compute.bwr(ohiovowels, use.f3 = TRUE)
+
+# Example usage with normalized F1 and F2
+bwr.normlobanov.2d <- compute.bwr(norm.lobanov(ohiovowels))
+}
+\keyword{methods}

--- a/man/compute.stdists.Rd
+++ b/man/compute.stdists.Rd
@@ -1,0 +1,37 @@
+\name{compute.stdists}
+\alias{compute.stdists}
+\title{Compute Standard Distances for Vowel Data}
+\description{
+  Computes the standard distances for uniquely named vowels, in a data frame of vowel formant data.
+}
+\usage{
+compute.stdists(vowels, use.f3 = FALSE)
+}
+\arguments{
+  \item{vowels}{A required data frame of the format: speaker_id, vowel_id, context, F1, F2, F3. The context column can be blank. The F3 column can also be blank if \code{use.f3} is \code{FALSE}.}
+  \item{use.f3}{A logical value indicating whether to include F3 values in the calculations. Default is \code{FALSE}.}
+}
+\details{
+  This function calculates the standard distances for each unique vowel in the provided data frame. The metric is calculated as the mean Euclidean distance of each data point for a single vowel category from the centroid for that category. It may be used to compare data spread for different vowel categories, but the measurements need to be on the same scale. Therefore, comparisons should not be made across different normalization methods. Larger values of this metric indicate larger data scatter.
+  By default, the function uses two-dimensional input (F1 and F2, or any corresponding normalized values), but for original data measured in Hz or data normalized using methods that return three values (such as Labov or Nearey), three-dimensional input is possible, based on the \code{use.f3} argument.
+}
+\value{
+  A data frame with the following columns:
+  \item{Vowel}{The unique vowel identifier.}
+  \item{N}{The count of samples for each vowel.}
+  \item{Standard.Distance}{The calculated standard distance for each vowel.}
+}
+\author{Stolarski, Lukasz <lukasz.stolarski@ujk.edu.pl>}
+\seealso{ \code{\link{compute.means}}, \code{\link{compute.medians}}, \code{\link{compute.sds}}, \code{\link{compute.bwr}} }
+\examples{
+# Example usage with F1 and F2
+data(ohiovowels)
+stdists.2d <- compute.stdists(ohiovowels)
+
+# Example usage with F1, F2, and F3
+stdists.3d <- compute.stdists(ohiovowels, use.f3 = TRUE)
+
+# Example usage with normalized F1 and F2
+stdists.lobanov.2d <- compute.stdists(norm.lobanov(ohiovowels))
+}
+\keyword{methods}


### PR DESCRIPTION
This pull request introduces two new functions to the vowels package: compute.stdists() and compute.bwr(). These functions provide essential metrics for analyzing clustering of vowel categories.

compute.stdists()

    Function: Computes the standard distances for uniquely named vowels in the provided data frame.
    Purpose: Measures the mean Euclidean distance from each data point to the centroid of its vowel category. This metric helps assess the spread of data points within each vowel category.
    Arguments:
        vowels: A data frame containing vowel formant data with columns for speaker ID, vowel ID, context, and formant frequencies (F1, F2, and optionally F3).
        use.f3: A logical flag indicating whether to include F3 values in the calculations.
    Output: A data frame with columns for vowel identifier, count of samples, and the computed standard distance for each vowel.
    Use Cases: Useful for comparing the variability of data within individual vowel categories. It is important that comparisons are made within the same normalization context.

compute.bwr()

    Function: Computes the Between-Within Ratio (BWR) for vowel data.
    Purpose: Calculates the ratio of the mean distance between categories to the mean distance within categories. This metric evaluates how well-separated vowel categories are and the spread of data within categories.
    Arguments:
        vowels: A data frame with vowel formant data similar to compute.stdists().
        use.f3: A logical flag for including F3 in the calculations.
    Output: A numeric value representing the ratio of between-category to within-category distances.
    Use Cases: Assessing vowel category separation and data spread withing categories across different normalization methods, with larger values indicating better separation.